### PR TITLE
Faster algorithm for cleaning strings

### DIFF
--- a/hidden.go
+++ b/hidden.go
@@ -11,8 +11,15 @@ import (
 	"github.com/getlantern/hex"
 )
 
-// 16 non-printing characters
-const hextable = "\x01\x02\x03\x04\x05\x06\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17"
+const (
+	// 16 non-printing characters
+	hextable = "\x01\x02\x03\x04\x05\x06\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17"
+
+	null = '\x00'
+	hex1 = '\x06'
+	hex2 = '\x0e'
+	hex3 = '\x17'
+)
 
 var (
 	hexencoding = hex.NewEncoding(hextable)
@@ -60,7 +67,14 @@ func Extract(str string) ([][]byte, error) {
 	return result, nil
 }
 
-// Clean removes any hidden data from an arbitrary string.
+// Clean removes all control characters that might be encoding hidden data from a given string.
 func Clean(str string) string {
-	return re.ReplaceAllString(str, "")
+	result := make([]byte, 0, len(str))
+	for _, b := range []byte(str) {
+		isNotHidden := b > hex3 || (b > hex1 && b < hex2)
+		if isNotHidden {
+			result = append(result, b)
+		}
+	}
+	return string(result)
 }

--- a/hidden_test.go
+++ b/hidden_test.go
@@ -19,15 +19,26 @@ func TestRoundTrip(t *testing.T) {
 
 func TestExtract(t *testing.T) {
 	a := []byte("Here is my string")
-	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, 56)
-	str := fmt.Sprintf("hidden%s data%s is fun", ToString(a), ToString(b))
+	d := make([]byte, 8)
+	binary.BigEndian.PutUint64(d, 56)
+	str := fmt.Sprintf("hidden%s \x11data%s is fun", ToString(a), ToString(d))
 	t.Log(str)
 	out, err := Extract(str)
 	if assert.NoError(t, err) {
 		if assert.Len(t, out, 2) {
-			assert.Equal(t, out, [][]byte{a, b})
+			assert.Equal(t, out, [][]byte{a, d})
 		}
 	}
 	assert.Equal(t, "hidden data is fun", Clean(str))
+}
+
+func BenchmarkClean(b *testing.B) {
+	a := []byte("Here is my string")
+	d := make([]byte, 8)
+	binary.BigEndian.PutUint64(d, 56)
+	str := fmt.Sprintf("hidden%s data%s is fun", ToString(a), ToString(d))
+	b.ResetTimer()
+	for i:=0; i<b.N; i++ {
+		Clean(str)
+	}
 }


### PR DESCRIPTION
I noticed a ton of allocation happening on cleaning hidden strings for logging purposes due to the use of a regex here. This new algorithm allocates a lot less and is also faster to boot.

```
ROUTINE ======================== github.com/getlantern/golog.(*logger).printf in /Users/ox.to.a.cart/gocode/pkg/mod/github.com/getlantern/hidden@v0.0.0-20190325191715-f02dbb02be55/hidden.go
         0   524.60MB (flat, cum) 53.97% of Total
         .          .     60:	return result, nil
         .          .     61:}
         .          .     62:
         .          .     63:// Clean removes any hidden data from an arbitrary string.
         .          .     64:func Clean(str string) string {
         .   524.60MB     65:	return re.ReplaceAllString(str, "")
         .          .     66:}
```

- [x] Do the tests pass? Consistently?